### PR TITLE
Fix wrong link to MultiWorld documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ MultiWorld is an addon to the randomizer where items are not only scattered thro
 
 [**ItemSync documentation**](ItemSyncMod/README.md)
 
-[**MultiWorld documentation**](ItemSyncMod/README.md)
+[**MultiWorld documentation**](MultiWorldMod/README.md)


### PR DESCRIPTION
The main README.md pointed at ItemSync's documentation twice, rather than pointing at MultiWorld's documentation.