### PR TITLE
Null check VoteEjectMenuInstance

### DIFF
--- a/MultiWorldMod/MultiWorldMod.cs
+++ b/MultiWorldMod/MultiWorldMod.cs
@@ -45,7 +45,7 @@ namespace MultiWorldMod
 
 			Controller?.UnloadMultiSetup();
 			Connection.Disconnect();
-			VoteEjectMenuInstance.Reset();
+			VoteEjectMenuInstance?.Reset();
 		}
 
 		void IGlobalSettings<GlobalSettings>.OnLoadGlobal(GlobalSettings s)


### PR DESCRIPTION
This can only be null if Initialize threw, but in that case the game breaks rather than letting you get to the menu.