### PR TITLE
Fix ItemSync restart bug by hard-coupling ClientConnection actions

### DIFF
--- a/ItemSyncMod/Connection/ClientConnection.cs
+++ b/ItemSyncMod/Connection/ClientConnection.cs
@@ -26,11 +26,6 @@ namespace ItemSyncMod
         private readonly List<MWConfirmableMessage> ConfirmableMessagesQueue = new();
         private Thread ReadThread;
 
-        internal Action<int, string[]> OnReadyConfirm;
-        internal Action<string> OnReadyDeny;
-        internal Action<ulong, string> OnConnect;
-        internal Action GameStarted;
-
         private readonly List<MWMessage> messageEventQueue = new();
 
         internal ClientConnection()
@@ -409,7 +404,7 @@ namespace ItemSyncMod
             State.Uid = message.SenderUid;
             State.Connected = true;
             Log($"Connected! (UID = {State.Uid})");
-            OnConnect?.Invoke(State.Uid, message.ServerName);
+            MenuHolder.MenuInstance?.ConnectionOnConnect(State.Uid, message.ServerName);
         }
 
         private void HandleJoinConfirm(MWJoinConfirmMessage message)
@@ -428,14 +423,11 @@ namespace ItemSyncMod
 
         private void HandleReadyConfirm(MWReadyConfirmMessage message)
         {
-            OnReadyConfirm?.Invoke(message.Ready, message.Names);
+            MenuHolder.MenuInstance?.ConnectionOnReadyConfirm(message.Ready, message.Names);
             SendMessage(new MWRequestSettingsMessage { });
         }
 
-        private void HandleReadyDeny(MWReadyDenyMessage message)
-        {
-            OnReadyDeny?.Invoke(message.Description);
-        }
+        private void HandleReadyDeny(MWReadyDenyMessage message) => MenuHolder.MenuInstance?.ConnectionOnReadyDeny(message.Description);
 
         private void HandleDataReceive(MWDataReceiveMessage message)
         {
@@ -502,7 +494,7 @@ namespace ItemSyncMod
             ItemSyncMod.ISSettings.SyncSimpleKeysUsages = ItemSyncMod.GS.SyncSimpleKeysUsages;
             ItemSyncMod.ISSettings.AdditionalFeaturesEnabled = ItemSyncMod.GS.AdditionalFeaturesEnabled;
 
-            GameStarted?.Invoke();
+            MenuHolder.MenuInstance?.ConnectionOnGameStarted();
         }
 
         internal void NotifySave()

--- a/ItemSyncMod/Menu/MenuHolder.cs
+++ b/ItemSyncMod/Menu/MenuHolder.cs
@@ -133,18 +133,23 @@ namespace ItemSyncMod.Menu
             additionalFeaturesToggleButton.SetValue(ItemSyncMod.GS.AdditionalFeaturesEnabled && !ItemSyncMod.GS.ReducePreload);
         }
 
+        internal void ConnectionOnConnect(ulong uid, string serverName) => ConnectAcknowledged(uid, serverName);
+
+        internal void ConnectionOnReadyConfirm(int ready, string[] names) => InvokeOnRoomStateUpdated(ready, names);
+
+        internal void ConnectionOnReadyDeny(string msg) => ThreadSupport.BeginInvoke(() => ShowReadyDeny(msg));
+
+        internal void ConnectionOnGameStarted() => InvokeOnGameStarted();
+
         private void AddEvents()
         {
             openMenuButton.AddHideAndShowEvent(menuPage);
             connectButton.OnClick += () => ThreadSupport.BeginInvoke(ConnectClicked);
-            ItemSyncMod.Connection.OnConnect = ConnectAcknowledged;
 
             nicknameInput.ValueChanged += (value) => ThreadSupport.BeginInvoke(() => UpdateNickname(value));
             nicknameInput.InputField.onValidateInput += (text, index, c) => c == ',' ? '.' : c; // ICU
 
             readyButton.OnClick += () => ThreadSupport.BeginInvoke(ReadyClicked);
-            ItemSyncMod.Connection.OnReadyConfirm = InvokeOnRoomStateUpdated;
-            ItemSyncMod.Connection.OnReadyDeny = (msg) => ThreadSupport.BeginInvoke(() => ShowReadyDeny(msg));
             OnRoomStateUpdated += (num, players) => ThreadSupport.BeginInvoke(() => UpdateReadyPlayersLabel(num, players));
             OnRoomStateUpdated += (_, _) => ThreadSupport.BeginInvoke(EnsureStartButtonShown);
 
@@ -165,7 +170,6 @@ namespace ItemSyncMod.Menu
             #endregion
 
             startButton.OnClick += () => ThreadSupport.BeginInvoke(InitiateGame);
-            ItemSyncMod.Connection.GameStarted = InvokeOnGameStarted;
             OnGameStarted += () => ThreadSupport.BeginInvoke(ShowJoinGameButton);
             OnGameStarted += () => ThreadSupport.BeginInvoke(openExtensionsMenuButton.Lock);
 

--- a/MultiWorldMod/Connection/ClientConnection.cs
+++ b/MultiWorldMod/Connection/ClientConnection.cs
@@ -27,11 +27,6 @@ namespace MultiWorldMod
         private readonly List<MWConfirmableMessage> ConfirmableMessagesQueue = new();
         private Thread ReadThread;
 
-        internal Action<int, string[]> OnReadyConfirm;
-        internal Action<string> OnReadyDeny;
-        internal Action<ulong, string> OnConnect;
-        internal Action GameStarted;
-
         private readonly List<MWMessage> messageEventQueue = new();
         
         internal ClientConnection()
@@ -443,7 +438,7 @@ namespace MultiWorldMod
             State.Uid = message.SenderUid;
             State.Connected = true;
             Log($"Connected! (UID = {State.Uid})");
-            OnConnect?.Invoke(State.Uid, message.ServerName);
+            MenuHolder.MenuInstance?.ConnectionOnConnect(State.Uid, message.ServerName);
         }
 
         private void HandleJoinConfirm(MWJoinConfirmMessage message)
@@ -460,15 +455,9 @@ namespace MultiWorldMod
             State.Joined = false;
         }
 
-        private void HandleReadyConfirm(MWReadyConfirmMessage message)
-        {
-            OnReadyConfirm?.Invoke(message.Ready, message.Names);
-        }
+        private void HandleReadyConfirm(MWReadyConfirmMessage message) => MenuHolder.MenuInstance?.ConnectionOnReadyConfirm(message.Ready, message.Names);
 
-        private void HandleReadyDeny(MWReadyDenyMessage message)
-        {
-            OnReadyDeny?.Invoke(message.Description);
-        }
+        private void HandleReadyDeny(MWReadyDenyMessage message) => MenuHolder.MenuInstance?.ConnectionOnReadyDeny(message.Description);
 
         private void HandleDataReceive(MWDataReceiveMessage message)
         {
@@ -554,8 +543,8 @@ namespace MultiWorldMod
             ItemManager.StoreOwnedItemsRemotePlacements(message.PlayerItemsPlacements);
             MultiWorldMod.Controller.SetGeneratedHash(message.GeneratedHash);
 
-            GameStarted += () => ItemsSpoiler.Save(message.ItemsSpoiler);
-            GameStarted?.Invoke();
+            MenuHolder.MenuInstance?.ConnectionOnGameStarted();
+            ItemsSpoiler.Save(message.ItemsSpoiler);
         }
 
         protected override void SendAndQueueData(string label, string data, int to, int ttl = Consts.DEFAULT_TTL, bool isOnJoin = false)

--- a/MultiWorldMod/Menu/MenuHolder.cs
+++ b/MultiWorldMod/Menu/MenuHolder.cs
@@ -144,23 +144,27 @@ namespace MultiWorldMod.Menu
             nicknameInput.SetValue(MultiWorldMod.GS.UserName);
         }
 
+        internal void ConnectionOnConnect(ulong uid, string serverName) => ConnectAcknowledged(uid, serverName);
+
+        internal void ConnectionOnReadyConfirm(int ready, string[] names) => InvokeOnRoomStateUpdated(ready, names);
+
+        internal void ConnectionOnReadyDeny(string msg) => ThreadSupport.BeginInvoke(() => ShowReadyDeny(msg));
+
+        internal void ConnectionOnGameStarted() => InvokeOnGameStarted();
+
         private void AddEvents()
         {
             openMenuButton.AddHideAndShowEvent(menuPage);
             connectButton.OnClick += () => ThreadSupport.BeginInvoke(ConnectClicked);
-            MultiWorldMod.Connection.OnConnect = ConnectAcknowledged;
 
             nicknameInput.ValueChanged += UpdateNickname;
             nicknameInput.InputField.onValidateInput += (text, index, c) => c == ',' ? '.' : c; // ICU
             
             readyButton.OnClick += () => ThreadSupport.BeginInvoke(ReadyClicked);
-            MultiWorldMod.Connection.OnReadyConfirm = InvokeOnRoomStateUpdated;
-            MultiWorldMod.Connection.OnReadyDeny = (msg) => ThreadSupport.BeginInvoke(() => ShowReadyDeny(msg));
             OnRoomStateUpdated += (num, players) => ThreadSupport.BeginInvoke(() => UpdateReadyPlayersLabel(num, players));
             OnRoomStateUpdated += (_, _) => ThreadSupport.BeginInvoke(EnsureStartButtonShown);
 
             startButton.OnClick += () => ThreadSupport.BeginInvoke(InitiateGame);
-            MultiWorldMod.Connection.GameStarted = InvokeOnGameStarted;
             OnGameStarted += () => ThreadSupport.BeginInvoke(ShowJoinGameButton);
 
             joinGameButton.OnClick += InvokeOnGameJoined;


### PR DESCRIPTION
This makes it so the ItemSync menu doesn't break when connecting to ItemSync a second time in the same HollowKnight game session, after returning to the main menu,

The issue is that randomizer menu construction (and thus ItemSync menu construction) runs *before* the scene-changed hook ItemSync uses to reset the ClientConnection, so the internal actions in ClientConnection are reset and the menu becomes defunct.  This PR directly links the actions to the MenuHolder instance instead so there's no state to be corrupted.

I also went ahead and fixed the same bug in MultiWorldMod, with a little more liberty taken on the 'GameStarted' action.  I couldn't see a reason why previous MWResults should be repeatedly rewritten and then immediately overwritten by the same multi-action (seems like a bug?) so I simplified the call site.