### PR TITLE
Fix incomplete list of placements being sent to the server

### DIFF
--- a/MultiWorldMod/Randomizer/OrderedItemPlacements.cs
+++ b/MultiWorldMod/Randomizer/OrderedItemPlacements.cs
@@ -31,6 +31,7 @@ namespace MultiWorldMod.Randomizer
         {
             MainUpdater mu = pm.mu;
             mu.AddWaypoints(rc.ctx.LM.Waypoints);
+            mu.AddTransitions(rc.ctx.LM.TransitionLookup.Values);
             mu.AddPlacements(rc.ctx.Vanilla);
 
             if (rc.ctx.transitionPlacements is not null)


### PR DESCRIPTION
Looking at TrackerData, we were missing a call to AddTransitions. This adds entries to the MainUpdater that manage state for transitions; this may explain why a randomizer update (presumably the state logic one?) broke our logic.

With the added call, every non-start placement in the spoiler log is sent, and appears in the shuffled spoiler log produced by the server.